### PR TITLE
Remove unsupported Node 8.x from CI test job matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2016]
-        node-version: [8.x, 10.x]
+        node-version: [10.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
Context:

- [Jest > 25 no longer supports Node < 10](https://github.com/facebook/jest/issues/10012), causing perpetual test failure for the Node 8.x test job matrix.
